### PR TITLE
Fix typo, add link to paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # LLM-Augmenter
 
-This repository will provide soon an implementation of LM-Augmenter, which is described in this paper:
+This repository will provide soon an implementation of LLM-Augmenter, which is described in this paper:
 
-**Check Your Facts and Try Again: Improving Large Language Models with External Knowledge and Automated Feedback**\
+[Check Your Facts and Try Again: Improving Large Language Models with External Knowledge and Automated Feedback](https://arxiv.org/abs/2302.12813)\
 *Baolin Peng, Michel Galley, Pengcheng He, Hao Cheng, Yujia Xie, Yu Hu, Qiuyuan Huang, Lars Liden, Zhou Yu, Weizhu Chen, Jianfeng Gao*
 
 #### Motivating example:


### PR DESCRIPTION
LM => LLM
Paper is now on arXiv so adding a link to the published location.